### PR TITLE
Use alpha_composite instead of paste

### DIFF
--- a/code/ribbonator.py
+++ b/code/ribbonator.py
@@ -113,7 +113,7 @@ class CelestialBody(object):
         base = self.base_ribbon()
         for d in self.devices:
             img = device_images[d]
-            base.paste(img, img)
+            base = Image.alpha_composite(base, img)
         return base
 
 class Star(CelestialBody):


### PR DESCRIPTION
Cleans up the fuzzy edges/'halos' around the devices.  Old above, new below:

![out-old](https://user-images.githubusercontent.com/9631860/76971413-8bd48300-6903-11ea-8b11-9a4f14c29a6e.png)

![out](https://user-images.githubusercontent.com/9631860/76971420-8d9e4680-6903-11ea-9f83-23cdc59d2bad.png)

I think the improvement is most clearly seen on the Moho, Mun, and Ike ribbons on the second row. 